### PR TITLE
SubnetID migration to ref-fvm. Cross-msg functions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,7 +1160,6 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
- "thiserror",
 ]
 
 [[package]]

--- a/actors/hierarchical-sca/Cargo.toml
+++ b/actors/hierarchical-sca/Cargo.toml
@@ -28,7 +28,6 @@ serde = { version = "1.0.136", features = ["derive"] }
 anyhow = "1.0.56"
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.2.0"
-thiserror = "1.0.30"
 
 [dev-dependencies]
 fil_actors_runtime = { version = "8.0.0-alpha.1", path = "../runtime", features = ["test_utils", "sector-default"] }

--- a/actors/hierarchical-sca/src/checkpoint.rs
+++ b/actors/hierarchical-sca/src/checkpoint.rs
@@ -1,15 +1,10 @@
-use super::subnet::SubnetID;
-use crate::StorableMsg;
 use anyhow::anyhow;
 use cid::multihash::Code;
 use cid::multihash::MultihashDigest;
 use cid::Cid;
-use fil_actors_runtime::Array;
-use fvm_ipld_blockstore::MemoryBlockstore;
-use fvm_ipld_encoding::to_vec;
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::CborStore;
-use fvm_ipld_encoding::{serde_bytes, Cbor};
+use fvm_ipld_encoding::{serde_bytes, to_vec, Cbor};
+use fvm_shared::address::SubnetID;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
@@ -147,54 +142,6 @@ pub struct ChildCheck {
     pub checks: Vec<Cid>,
 }
 impl Cbor for ChildCheck {}
-
-#[derive(PartialEq, Eq, Clone, Debug, Default, Serialize_tuple, Deserialize_tuple)]
-pub struct CrossMsgs {
-    pub msgs: Vec<StorableMsg>,
-    pub metas: Vec<CrossMsgMeta>,
-}
-impl Cbor for CrossMsgs {}
-
-#[derive(PartialEq, Eq, Clone, Debug, Default, Serialize_tuple, Deserialize_tuple)]
-pub struct MetaTag {
-    pub msgs_cid: Cid,
-    pub meta_cid: Cid,
-}
-impl Cbor for MetaTag {}
-
-impl CrossMsgs {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub(crate) fn cid(&self) -> anyhow::Result<Cid> {
-        let store = MemoryBlockstore::new();
-        let mut msgs_array = Array::new(&store);
-        msgs_array.batch_set(self.msgs.clone())?;
-        let msgs_cid = msgs_array
-            .flush()
-            .map_err(|e| anyhow!("Failed to create empty messages array: {}", e))?;
-
-        let mut meta_array = Array::new(&store);
-        meta_array.batch_set(self.msgs.clone())?;
-        let meta_cid = meta_array
-            .flush()
-            .map_err(|e| anyhow!("Failed to create empty messages array: {}", e))?;
-
-        Ok(store.put_cbor(&MetaTag { msgs_cid: msgs_cid, meta_cid: meta_cid }, Code::Blake2b256)?)
-    }
-
-    pub(crate) fn add_metas(&mut self, metas: Vec<CrossMsgMeta>) -> anyhow::Result<()> {
-        for m in metas.iter() {
-            if self.metas.iter().any(|ms| ms == m) {
-                continue;
-            }
-            self.metas.push(m.clone());
-        }
-
-        Ok(())
-    }
-}
 
 /// CheckpointEpoch returns the epoch of the next checkpoint
 /// that needs to be signed

--- a/actors/hierarchical-sca/src/cross.rs
+++ b/actors/hierarchical-sca/src/cross.rs
@@ -1,0 +1,86 @@
+use anyhow::anyhow;
+use cid::multihash::Code;
+use cid::Cid;
+use fil_actors_runtime::Array;
+use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_ipld_encoding::tuple::*;
+use fvm_ipld_encoding::Cbor;
+use fvm_ipld_encoding::{CborStore, RawBytes};
+use fvm_shared::address::Address;
+use fvm_shared::bigint::bigint_ser;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::MethodNum;
+
+use crate::checkpoint::CrossMsgMeta;
+
+/// StorableMsg stores all the relevant information required
+/// to execute cross-messages.
+///
+/// We follow this approach because we can't directly store types.Message
+/// as we did in the actor's Go counter-part. Instead we just persist the
+/// information required to create the cross-messages and execute in the
+/// corresponding node implementation.
+#[derive(PartialEq, Eq, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
+pub struct StorableMsg {
+    pub from: Address,
+    pub to: Address,
+    pub method: MethodNum,
+    pub params: RawBytes,
+    #[serde(with = "bigint_ser")]
+    pub value: TokenAmount,
+}
+impl Cbor for StorableMsg {}
+
+impl StorableMsg {
+    pub fn new_fund_msg() {
+        panic!("not implemented");
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, Debug, Default, Serialize_tuple, Deserialize_tuple)]
+pub struct CrossMsgs {
+    pub msgs: Vec<StorableMsg>,
+    pub metas: Vec<CrossMsgMeta>,
+}
+impl Cbor for CrossMsgs {}
+
+#[derive(PartialEq, Eq, Clone, Debug, Default, Serialize_tuple, Deserialize_tuple)]
+pub struct MetaTag {
+    pub msgs_cid: Cid,
+    pub meta_cid: Cid,
+}
+impl Cbor for MetaTag {}
+
+impl CrossMsgs {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn cid(&self) -> anyhow::Result<Cid> {
+        let store = MemoryBlockstore::new();
+        let mut msgs_array = Array::new(&store);
+        msgs_array.batch_set(self.msgs.clone())?;
+        let msgs_cid = msgs_array
+            .flush()
+            .map_err(|e| anyhow!("Failed to create empty messages array: {}", e))?;
+
+        let mut meta_array = Array::new(&store);
+        meta_array.batch_set(self.msgs.clone())?;
+        let meta_cid = meta_array
+            .flush()
+            .map_err(|e| anyhow!("Failed to create empty messages array: {}", e))?;
+
+        Ok(store.put_cbor(&MetaTag { msgs_cid: msgs_cid, meta_cid: meta_cid }, Code::Blake2b256)?)
+    }
+
+    pub(crate) fn add_metas(&mut self, metas: Vec<CrossMsgMeta>) -> anyhow::Result<()> {
+        for m in metas.iter() {
+            if self.metas.iter().any(|ms| ms == m) {
+                continue;
+            }
+            self.metas.push(m.clone());
+        }
+
+        Ok(())
+    }
+}

--- a/actors/hierarchical-sca/src/cross.rs
+++ b/actors/hierarchical-sca/src/cross.rs
@@ -11,6 +11,7 @@ use fvm_shared::bigint::bigint_ser;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::MethodNum;
 use fvm_shared::METHOD_SEND;
+use std::path::Path;
 
 use crate::checkpoint::CrossMsgMeta;
 
@@ -32,6 +33,13 @@ pub struct StorableMsg {
     pub nonce: u64,
 }
 impl Cbor for StorableMsg {}
+
+#[derive(PartialEq, Eq)]
+pub enum HCMsgType {
+    Unknown = 0,
+    BottomUp,
+    TopDown,
+}
 
 impl StorableMsg {
     pub fn new_release_msg(
@@ -80,6 +88,24 @@ impl StorableMsg {
             nonce: 0,
         })
     }
+
+    pub fn hc_type(&self) -> anyhow::Result<HCMsgType> {
+        let sto = self.to.subnet()?;
+        let sfrom = self.from.subnet()?;
+        if is_bottomup(&sfrom, &sto) {
+            return Ok(HCMsgType::BottomUp);
+        }
+        Ok(HCMsgType::TopDown)
+    }
+}
+
+pub fn is_bottomup(from: &SubnetID, to: &SubnetID) -> bool {
+    let index = match from.common_parent(&to) {
+        Some((ind, _)) => ind,
+        None => return false,
+    };
+    let a = from.to_string();
+    Path::new(&a).components().count() - 1 > index
 }
 
 #[derive(PartialEq, Eq, Clone, Debug, Default, Serialize_tuple, Deserialize_tuple)]
@@ -133,5 +159,27 @@ impl CrossMsgs {
         // TODO: Check if the message has already been added.
         self.msgs.push(msg.clone());
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cross::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_is_bottomup() {
+        bottom_up("/root/f01", "/root/f01/f02", false);
+        bottom_up("/root/f01", "/root", true);
+        bottom_up("/root/f01", "/root/f01/f02", false);
+        bottom_up("/root/f01", "/root/f02/f02", true);
+        bottom_up("/root/f01/f02", "/root/f01/f02", false);
+        bottom_up("/root/f01/f02", "/root/f01/f02/f03", false);
+    }
+    fn bottom_up(a: &str, b: &str, res: bool) {
+        assert_eq!(
+            is_bottomup(&SubnetID::from_str(a).unwrap(), &SubnetID::from_str(b).unwrap()),
+            res
+        );
     }
 }

--- a/actors/hierarchical-sca/src/ext.rs
+++ b/actors/hierarchical-sca/src/ext.rs
@@ -1,1 +1,3 @@
-pub mod subnet {}
+pub mod account {
+    pub const PUBKEY_ADDRESS_METHOD: u64 = 2;
+}

--- a/actors/hierarchical-sca/src/lib.rs
+++ b/actors/hierarchical-sca/src/lib.rs
@@ -19,7 +19,7 @@ use num_traits::FromPrimitive;
 use std::collections::HashMap;
 
 pub use self::checkpoint::{Checkpoint, CrossMsgMeta};
-pub use self::cross::{CrossMsgs, HCMsgType, StorableMsg};
+pub use self::cross::{is_bottomup, CrossMsgs, HCMsgType, StorableMsg};
 pub use self::state::*;
 pub use self::subnet::*;
 pub use self::types::*;

--- a/actors/hierarchical-sca/src/state.rs
+++ b/actors/hierarchical-sca/src/state.rs
@@ -515,6 +515,22 @@ impl State {
         Ok(())
     }
 
+    /// commits a cross-msg for propagation
+    pub(crate) fn send_cross<BS: Blockstore>(
+        &mut self,
+        store: &BS,
+        msg: &mut StorableMsg,
+        curr_epoch: ChainEpoch,
+    ) -> anyhow::Result<HCMsgType> {
+        let tp = msg.hc_type()?;
+        match tp {
+            HCMsgType::TopDown => self.commit_topdown_msg(store, msg)?,
+            HCMsgType::BottomUp => self.commit_bottomup_msg(store, msg, curr_epoch)?,
+            _ => return Err(anyhow!("cross-msg is not of the right type")),
+        };
+        Ok(tp)
+    }
+
     /// noop is triggered to notify when a crossMsg fails to be applied successfully.
     pub fn noop_msg(&self) {
         panic!("error committing cross-msg. noop should be returned but not implemented yet");

--- a/actors/hierarchical-sca/src/state.rs
+++ b/actors/hierarchical-sca/src/state.rs
@@ -10,6 +10,7 @@ use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;
 use fvm_ipld_hamt::BytesKey;
+use fvm_shared::address::SubnetID;
 use fvm_shared::bigint::{bigint_ser, BigInt};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
@@ -21,6 +22,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use super::checkpoint::*;
+use super::cross::*;
 use super::subnet::*;
 use super::types::*;
 

--- a/actors/hierarchical-sca/src/subnet.rs
+++ b/actors/hierarchical-sca/src/subnet.rs
@@ -9,7 +9,9 @@ use fvm_shared::bigint::bigint_ser;
 use fvm_shared::econ::TokenAmount;
 
 use super::checkpoint::*;
+use super::cross::StorableMsg;
 use super::state::State;
+use super::types::*;
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Deserialize_repr, Serialize_repr)]
 #[repr(i32)]
@@ -48,6 +50,23 @@ impl Subnet {
             self.status = Status::Inactive;
         }
         st.flush_subnet(rt.store(), self)
+    }
+
+    /// store topdown messages for their execution in the subnet
+    pub(crate) fn store_topdown_msg<BS: Blockstore>(
+        &mut self,
+        store: &BS,
+        msg: &StorableMsg,
+    ) -> anyhow::Result<()> {
+        let mut crossmsgs = CrossMsgArray::load(&self.top_down_msgs, store)
+            .map_err(|e| anyhow!("failed to load crossmsg meta array: {}", e))?;
+
+        crossmsgs
+            .set(msg.nonce, msg.clone())
+            .map_err(|e| anyhow!("failed to set crossmsg meta array: {}", e))?;
+        self.top_down_msgs = crossmsgs.flush()?;
+
+        Ok(())
     }
 
     pub(crate) fn release_supply(&mut self, value: &TokenAmount) -> anyhow::Result<()> {

--- a/actors/hierarchical-sca/src/subnet.rs
+++ b/actors/hierarchical-sca/src/subnet.rs
@@ -4,124 +4,12 @@ use fil_actors_runtime::runtime::Runtime;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::repr::*;
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::Cbor;
-use fvm_shared::address::Address;
+use fvm_shared::address::SubnetID;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::econ::TokenAmount;
-use lazy_static::lazy_static;
-use std::fmt;
-use std::path::Path;
-use std::str::FromStr;
-use thiserror::Error;
 
 use super::checkpoint::*;
 use super::state::State;
-
-#[derive(PartialEq, Eq, Hash, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
-pub struct SubnetID {
-    parent: String,
-    actor: Address,
-}
-impl Cbor for SubnetID {}
-
-lazy_static! {
-    pub static ref ROOTNET_ID: SubnetID =
-        SubnetID { parent: String::from("/root"), actor: Address::new_id(0) };
-}
-
-#[derive(Debug, PartialEq, Error)]
-pub enum Error {
-    #[error("invalid subnet id")]
-    InvalidID,
-}
-
-impl SubnetID {
-    pub fn new(parent: &SubnetID, subnet_act: Address) -> SubnetID {
-        let parent_str = parent.to_string();
-
-        return SubnetID { parent: parent_str, actor: subnet_act };
-    }
-
-    pub fn to_bytes(&self) -> Vec<u8> {
-        let str_id = self.to_string();
-        str_id.into_bytes()
-    }
-
-    pub fn subnet_actor(&self) -> Address {
-        self.actor
-    }
-
-    pub fn parent(&self) -> Option<SubnetID> {
-        if *self == *ROOTNET_ID {
-            return None;
-        }
-        match SubnetID::from_str(&self.parent) {
-            Ok(id) => Some(id),
-            Err(_) => None,
-        }
-    }
-
-    // pub fn common_parent(other: &SubnetID) -> Result<SubnetID, Error> {
-    //     panic!("not implemented")
-    // }
-    // pub fn down(other: &SubnetID) -> Result<SubnetID, Error> {
-    //     panic!("not implemented")
-    // }
-    // pub fn up(other: &SubnetID) -> Result<SubnetID, Error> {
-    //     panic!("not implemented")
-    // }
-}
-
-impl fmt::Display for SubnetID {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.parent == "/root" && self.actor == Address::new_id(0) {
-            return write!(f, "{}", self.parent);
-        }
-        let act_str = self.actor.to_string();
-        match Path::join(Path::new(&self.parent), Path::new(&act_str)).to_str() {
-            Some(r) => write!(f, "{}", r),
-            None => Err(fmt::Error),
-        }
-    }
-}
-
-impl Default for SubnetID {
-    fn default() -> Self {
-        Self { parent: String::from(""), actor: Address::new_id(0) }
-    }
-}
-
-impl FromStr for SubnetID {
-    type Err = Error;
-    fn from_str(addr: &str) -> Result<Self, Error> {
-        if addr == ROOTNET_ID.to_string() {
-            return Ok(ROOTNET_ID.clone());
-        }
-
-        let id = Path::new(addr);
-        let act = match Path::file_name(id) {
-            Some(act_str) => Address::from_str(act_str.to_str().unwrap_or("")),
-            None => return Err(Error::InvalidID),
-        };
-
-        let mut anc = id.ancestors();
-        _ = anc.next();
-        let par = match anc.next() {
-            Some(par_str) => par_str.to_str(),
-            None => return Err(Error::InvalidID),
-        }
-        .ok_or(Error::InvalidID)
-        .unwrap();
-
-        Ok(Self {
-            parent: String::from(par),
-            actor: match act {
-                Ok(addr) => addr,
-                Err(_) => return Err(Error::InvalidID),
-            },
-        })
-    }
-}
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Deserialize_repr, Serialize_repr)]
 #[repr(i32)]
@@ -170,27 +58,5 @@ impl Subnet {
         }
         self.circ_supply -= value;
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::subnet::*;
-    use fvm_shared::address::Address;
-
-    #[test]
-    fn test_subnet_id() {
-        let act = Address::new_id(1001);
-        let sub_id = SubnetID::new(&ROOTNET_ID.clone(), act);
-        let sub_id_str = sub_id.to_string();
-        assert_eq!(sub_id_str, "/root/f01001");
-
-        let rtt_id = SubnetID::from_str(&sub_id_str).unwrap();
-        assert_eq!(sub_id, rtt_id);
-
-        let rootnet = ROOTNET_ID.clone();
-        assert_eq!(rootnet.to_string(), "/root");
-        let root_sub = SubnetID::from_str(&rootnet.to_string()).unwrap();
-        assert_eq!(root_sub, rootnet);
     }
 }

--- a/actors/hierarchical-sca/src/types.rs
+++ b/actors/hierarchical-sca/src/types.rs
@@ -1,5 +1,6 @@
 use fil_actors_runtime::Array;
 use fvm_ipld_encoding::tuple::*;
+use fvm_shared::address::SubnetID;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
@@ -30,4 +31,10 @@ pub struct FundParams {
 #[derive(Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct CheckpointParams {
     pub checkpoint: Checkpoint,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
+pub struct CrossMsgParams {
+    pub msg: StorableMsg,
+    pub destination: SubnetID,
 }

--- a/actors/hierarchical-sca/src/types.rs
+++ b/actors/hierarchical-sca/src/types.rs
@@ -1,12 +1,9 @@
 use super::checkpoint::{Checkpoint, CrossMsgMeta};
 use fil_actors_runtime::Array;
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_encoding::RawBytes;
-use fvm_shared::address::Address;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
-use fvm_shared::MethodNum;
 
 pub const CROSSMSG_AMT_BITWIDTH: u32 = 3;
 pub const DEFAULT_CHECKPOINT_PERIOD: ChainEpoch = 10;
@@ -35,21 +32,4 @@ pub struct CheckpointParams {
 #[derive(Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct SubnetIDParam {
     pub id: String,
-}
-
-/// StorableMsg stores all the relevant information required
-/// to execute cross-messages.
-///
-/// We follow this approach because we can't directly store types.Message
-/// as we did in the actor's Go counter-part. Instead we just persist the
-/// information required to create the cross-messages and execute in the
-/// corresponding node implementation.
-#[derive(PartialEq, Eq, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
-pub struct StorableMsg {
-    pub from: Address,
-    pub to: Address,
-    pub method: MethodNum,
-    pub params: RawBytes,
-    #[serde(with = "bigint_ser")]
-    pub value: TokenAmount,
 }

--- a/actors/hierarchical-sca/src/types.rs
+++ b/actors/hierarchical-sca/src/types.rs
@@ -1,9 +1,11 @@
-use super::checkpoint::{Checkpoint, CrossMsgMeta};
 use fil_actors_runtime::Array;
 use fvm_ipld_encoding::tuple::*;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
+
+use crate::checkpoint::{Checkpoint, CrossMsgMeta};
+use crate::StorableMsg;
 
 pub const CROSSMSG_AMT_BITWIDTH: u32 = 3;
 pub const DEFAULT_CHECKPOINT_PERIOD: ChainEpoch = 10;
@@ -11,6 +13,7 @@ pub const MAX_NONCE: u64 = 1 << 63;
 pub const MIN_COLLATERAL_AMOUNT: u64 = 10_u64.pow(18);
 
 pub type CrossMsgMetaArray<'bs, BS> = Array<'bs, CrossMsgMeta, BS>;
+pub type CrossMsgArray<'bs, BS> = Array<'bs, StorableMsg, BS>;
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct ConstructorParams {
@@ -27,9 +30,4 @@ pub struct FundParams {
 #[derive(Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct CheckpointParams {
     pub checkpoint: Checkpoint,
-}
-
-#[derive(Debug, Serialize_tuple, Deserialize_tuple)]
-pub struct SubnetIDParam {
-    pub id: String,
 }

--- a/actors/hierarchical-sca/tests/harness/mod.rs
+++ b/actors/hierarchical-sca/tests/harness/mod.rs
@@ -5,7 +5,6 @@ use cid::Cid;
 use fil_actors_runtime::test_utils::expect_abort;
 use fil_actors_runtime::Array;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::Cbor;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::subnet::ROOTNET_ID;
 use fvm_shared::address::{Address, SubnetID};
@@ -454,5 +453,5 @@ fn get_cross_msgs<'m, BS: Blockstore>(
     registry: &'m Map<BS, CrossMsgs>,
     cid: &Cid,
 ) -> anyhow::Result<Option<&'m CrossMsgs>> {
-    registry.get(&cid.to_bytes()).map_err(|e| anyhow!("error getting fross messages"))
+    registry.get(&cid.to_bytes()).map_err(|e| anyhow!("error getting fross messages: {}", e))
 }

--- a/actors/hierarchical-sca/tests/harness/mod.rs
+++ b/actors/hierarchical-sca/tests/harness/mod.rs
@@ -4,7 +4,8 @@ use cid::Cid;
 use fil_actors_runtime::test_utils::expect_abort;
 use fil_actors_runtime::Array;
 use fvm_ipld_encoding::RawBytes;
-use fvm_shared::address::Address;
+use fvm_shared::address::subnet::ROOTNET_ID;
+use fvm_shared::address::{Address, SubnetID};
 use fvm_shared::bigint::bigint_ser::BigIntDe;
 use fvm_shared::bigint::Zero;
 use fvm_shared::econ::TokenAmount;
@@ -22,9 +23,8 @@ use fil_actors_runtime::{
 };
 use hierarchical_sca::checkpoint::ChildCheck;
 use hierarchical_sca::{
-    Checkpoint, ConstructorParams, CrossMsgMeta, FundParams, Method, State, Subnet, SubnetID,
-    SubnetIDParam, CROSSMSG_AMT_BITWIDTH, DEFAULT_CHECKPOINT_PERIOD, MAX_NONCE,
-    MIN_COLLATERAL_AMOUNT, ROOTNET_ID,
+    Checkpoint, ConstructorParams, CrossMsgMeta, FundParams, Method, State, Subnet, SubnetIDParam,
+    CROSSMSG_AMT_BITWIDTH, DEFAULT_CHECKPOINT_PERIOD, MAX_NONCE, MIN_COLLATERAL_AMOUNT,
 };
 
 use crate::SCAActor;
@@ -303,6 +303,7 @@ pub fn add_msg_meta(
 ) {
     let mh_code = Code::Blake2b256;
     let c = Cid::new_v1(fvm_ipld_encoding::DAG_CBOR, mh_code.digest(&rand));
-    let meta = CrossMsgMeta { from: from.clone(), to: to.clone(), msgs_cid: c, nonce: 0, value: value };
+    let meta =
+        CrossMsgMeta { from: from.clone(), to: to.clone(), msgs_cid: c, nonce: 0, value: value };
     ch.append_msgmeta(meta).unwrap();
 }

--- a/actors/hierarchical-sca/tests/harness/mod.rs
+++ b/actors/hierarchical-sca/tests/harness/mod.rs
@@ -1,8 +1,11 @@
+use anyhow::anyhow;
 use cid::multihash::Code;
 use cid::multihash::MultihashDigest;
 use cid::Cid;
 use fil_actors_runtime::test_utils::expect_abort;
 use fil_actors_runtime::Array;
+use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::Cbor;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::subnet::ROOTNET_ID;
 use fvm_shared::address::{Address, SubnetID};
@@ -16,15 +19,20 @@ use lazy_static::lazy_static;
 
 use fil_actors_runtime::builtin::HAMT_BIT_WIDTH;
 use fil_actors_runtime::runtime::Runtime;
-use fil_actors_runtime::test_utils::{MockRuntime, SUBNET_ACTOR_CODE_ID, SYSTEM_ACTOR_CODE_ID};
+use fil_actors_runtime::test_utils::{
+    MockRuntime, ACCOUNT_ACTOR_CODE_ID, MULTISIG_ACTOR_CODE_ID, SUBNET_ACTOR_CODE_ID,
+    SYSTEM_ACTOR_CODE_ID,
+};
 use fil_actors_runtime::{
-    make_map_with_root_and_bitwidth, ActorError, BURNT_FUNDS_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
-    SYSTEM_ACTOR_ADDR,
+    make_map_with_root_and_bitwidth, ActorError, Map, BURNT_FUNDS_ACTOR_ADDR,
+    STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
 use hierarchical_sca::checkpoint::ChildCheck;
+use hierarchical_sca::ext;
 use hierarchical_sca::{
-    Checkpoint, ConstructorParams, CrossMsgMeta, FundParams, Method, State, Subnet,
-    CROSSMSG_AMT_BITWIDTH, DEFAULT_CHECKPOINT_PERIOD, MAX_NONCE, MIN_COLLATERAL_AMOUNT,
+    get_topdown_msg, Checkpoint, ConstructorParams, CrossMsgArray, CrossMsgMeta, CrossMsgs,
+    FundParams, Method, State, Subnet, CROSSMSG_AMT_BITWIDTH, DEFAULT_CHECKPOINT_PERIOD, MAX_NONCE,
+    MIN_COLLATERAL_AMOUNT,
 };
 
 use crate::SCAActor;
@@ -32,6 +40,8 @@ use crate::SCAActor;
 lazy_static! {
     pub static ref SUBNET_ONE: Address = Address::new_id(101);
     pub static ref SUBNET_TWO: Address = Address::new_id(202);
+    pub static ref TEST_BLS: Address =
+        Address::new_bls(&[1; fvm_shared::address::BLS_PUB_LEN]).unwrap();
     pub static ref ACTOR: Address = Address::new_actor("actor".as_bytes());
 }
 
@@ -44,13 +54,17 @@ pub fn new_runtime() -> MockRuntime {
     }
 }
 
-pub fn new_harness() -> Harness {
-    Harness { net_name: ROOTNET_ID.clone() }
+pub fn new_harness(id: SubnetID) -> Harness {
+    Harness { net_name: id }
 }
 
-pub fn setup() -> (Harness, MockRuntime) {
+pub fn setup_root() -> (Harness, MockRuntime) {
+    setup(ROOTNET_ID.clone())
+}
+
+pub fn setup(id: SubnetID) -> (Harness, MockRuntime) {
     let mut rt = new_runtime();
-    let h = new_harness();
+    let h = new_harness(id);
     h.construct(&mut rt);
     (h, rt)
 }
@@ -113,7 +127,7 @@ impl Harness {
             return Ok(());
         }
 
-        let register_ret = SubnetID::new(&ROOTNET_ID, *subnet_addr);
+        let register_ret = SubnetID::new(&self.net_name, *subnet_addr);
         let ret = rt.call::<SCAActor>(Method::Register as MethodNum, &RawBytes::default()).unwrap();
         rt.verify();
         let ret: SubnetID = RawBytes::deserialize(&ret).unwrap();
@@ -264,6 +278,135 @@ impl Harness {
         Ok(())
     }
 
+    pub fn fund(
+        &self,
+        rt: &mut MockRuntime,
+        funder: &Address,
+        id: &SubnetID,
+        code: ExitCode,
+        value: TokenAmount,
+        expected_nonce: u64,
+        expected_circ_sup: &TokenAmount,
+    ) -> Result<(), ActorError> {
+        rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *funder);
+        rt.expect_validate_caller_type(vec![*ACCOUNT_ACTOR_CODE_ID, *MULTISIG_ACTOR_CODE_ID]);
+
+        rt.set_value(value.clone());
+        if code != ExitCode::OK {
+            expect_abort(
+                code,
+                rt.call::<SCAActor>(
+                    Method::Fund as MethodNum,
+                    &RawBytes::serialize(id.clone()).unwrap(),
+                ),
+            );
+            rt.verify();
+            return Ok(());
+        }
+
+        rt.expect_send(
+            *funder,
+            ext::account::PUBKEY_ADDRESS_METHOD,
+            RawBytes::default(),
+            TokenAmount::zero(),
+            RawBytes::serialize(*TEST_BLS).unwrap(),
+            ExitCode::OK,
+        );
+        rt.call::<SCAActor>(Method::Fund as MethodNum, &RawBytes::serialize(id.clone()).unwrap())
+            .unwrap();
+        rt.verify();
+
+        let sub = self.get_subnet(rt, id).unwrap();
+        let crossmsgs = CrossMsgArray::load(&sub.top_down_msgs, rt.store()).unwrap();
+        let msg = get_topdown_msg(&crossmsgs, expected_nonce - 1).unwrap().unwrap();
+        assert_eq!(&sub.circ_supply, expected_circ_sup);
+        assert_eq!(sub.nonce, expected_nonce);
+        let from = Address::new_hierarchical(&self.net_name, &TEST_BLS).unwrap();
+        let to = Address::new_hierarchical(&id, &TEST_BLS).unwrap();
+        assert_eq!(msg.from, from);
+        assert_eq!(msg.to, to);
+        assert_eq!(msg.nonce, expected_nonce - 1);
+        assert_eq!(msg.value, value);
+
+        Ok(())
+    }
+
+    pub fn release(
+        &self,
+        rt: &mut MockRuntime,
+        releaser: &Address,
+        code: ExitCode,
+        value: TokenAmount,
+        expected_nonce: u64,
+        prev_meta: &Cid,
+    ) -> Result<Cid, ActorError> {
+        rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *releaser);
+        rt.expect_validate_caller_type(vec![*ACCOUNT_ACTOR_CODE_ID, *MULTISIG_ACTOR_CODE_ID]);
+
+        rt.set_value(value.clone());
+        if code != ExitCode::OK {
+            expect_abort(
+                code,
+                rt.call::<SCAActor>(Method::Release as MethodNum, &RawBytes::default()),
+            );
+            rt.verify();
+            return Ok(Cid::default());
+        }
+
+        rt.expect_send(
+            *releaser,
+            ext::account::PUBKEY_ADDRESS_METHOD,
+            RawBytes::default(),
+            TokenAmount::zero(),
+            RawBytes::serialize(*TEST_BLS).unwrap(),
+            ExitCode::OK,
+        );
+        rt.expect_send(
+            *BURNT_FUNDS_ACTOR_ADDR,
+            METHOD_SEND,
+            RawBytes::default(),
+            value.clone(),
+            RawBytes::default(),
+            ExitCode::OK,
+        );
+        rt.call::<SCAActor>(Method::Release as MethodNum, &RawBytes::default()).unwrap();
+        rt.verify();
+
+        let st: State = rt.get_state();
+
+        let parent = &self.net_name.parent().unwrap();
+        let from = Address::new_hierarchical(&self.net_name, &BURNT_FUNDS_ACTOR_ADDR).unwrap();
+        let to = Address::new_hierarchical(&parent, &TEST_BLS).unwrap();
+        rt.set_epoch(0);
+        let ch = st.get_window_checkpoint(rt.store(), 0).unwrap();
+        let chmeta_ind = ch.crossmsg_meta_index(&self.net_name, &parent).unwrap();
+        let chmeta = &ch.data.cross_msgs[chmeta_ind];
+
+        let cross_reg = make_map_with_root_and_bitwidth::<_, CrossMsgs>(
+            &st.check_msg_registry,
+            rt.store(),
+            HAMT_BIT_WIDTH,
+        )
+        .unwrap();
+        let meta = get_cross_msgs(&cross_reg, &chmeta.msgs_cid).unwrap().unwrap();
+        let msg = meta.msgs[expected_nonce as usize].clone();
+
+        assert_eq!(meta.msgs.len(), (expected_nonce + 1) as usize);
+        assert_eq!(msg.from, from);
+        assert_eq!(msg.to, to);
+        assert_eq!(msg.nonce, expected_nonce);
+        assert_eq!(msg.value, value);
+
+        if prev_meta != &Cid::default() {
+            match get_cross_msgs(&cross_reg, &prev_meta).unwrap() {
+                Some(_) => panic!("previous meta should have been removed"),
+                None => {}
+            }
+        }
+
+        Ok(chmeta.msgs_cid)
+    }
+
     pub fn check_state(&self) {
         // TODO: https://github.com/filecoin-project/builtin-actors/issues/44
     }
@@ -305,4 +448,11 @@ pub fn add_msg_meta(
     let meta =
         CrossMsgMeta { from: from.clone(), to: to.clone(), msgs_cid: c, nonce: 0, value: value };
     ch.append_msgmeta(meta).unwrap();
+}
+
+fn get_cross_msgs<'m, BS: Blockstore>(
+    registry: &'m Map<BS, CrossMsgs>,
+    cid: &Cid,
+) -> anyhow::Result<Option<&'m CrossMsgs>> {
+    registry.get(&cid.to_bytes()).map_err(|e| anyhow!("error getting fross messages"))
 }

--- a/actors/hierarchical-sca/tests/harness/mod.rs
+++ b/actors/hierarchical-sca/tests/harness/mod.rs
@@ -23,7 +23,7 @@ use fil_actors_runtime::{
 };
 use hierarchical_sca::checkpoint::ChildCheck;
 use hierarchical_sca::{
-    Checkpoint, ConstructorParams, CrossMsgMeta, FundParams, Method, State, Subnet, SubnetIDParam,
+    Checkpoint, ConstructorParams, CrossMsgMeta, FundParams, Method, State, Subnet,
     CROSSMSG_AMT_BITWIDTH, DEFAULT_CHECKPOINT_PERIOD, MAX_NONCE, MIN_COLLATERAL_AMOUNT,
 };
 
@@ -113,12 +113,11 @@ impl Harness {
             return Ok(());
         }
 
-        let register_ret =
-            SubnetIDParam { id: SubnetID::new(&ROOTNET_ID, *subnet_addr).to_string() };
+        let register_ret = SubnetID::new(&ROOTNET_ID, *subnet_addr);
         let ret = rt.call::<SCAActor>(Method::Register as MethodNum, &RawBytes::default()).unwrap();
         rt.verify();
-        let ret: SubnetIDParam = RawBytes::deserialize(&ret).unwrap();
-        assert_eq!(ret.id, register_ret.id);
+        let ret: SubnetID = RawBytes::deserialize(&ret).unwrap();
+        assert_eq!(ret, register_ret);
         Ok(())
     }
 

--- a/actors/hierarchical-sca/tests/sca_actor_test.rs
+++ b/actors/hierarchical-sca/tests/sca_actor_test.rs
@@ -1,11 +1,11 @@
 use fil_actors_runtime::runtime::Runtime;
-use fvm_shared::address::Address;
+use fvm_shared::address::{Address, SubnetID};
 use fvm_shared::bigint::Zero;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use hierarchical_sca::{
-    get_bottomup_msg, subnet, Actor as SCAActor, Checkpoint, CrossMsgMetaArray, State, SubnetID,
+    get_bottomup_msg, subnet, Actor as SCAActor, Checkpoint, CrossMsgMetaArray, State,
     DEFAULT_CHECKPOINT_PERIOD,
 };
 use std::str::FromStr;

--- a/actors/hierarchical-sca/tests/sca_actor_test.rs
+++ b/actors/hierarchical-sca/tests/sca_actor_test.rs
@@ -1,4 +1,6 @@
+use cid::Cid;
 use fil_actors_runtime::runtime::Runtime;
+use fvm_shared::address::subnet::ROOTNET_ID;
 use fvm_shared::address::{Address, SubnetID};
 use fvm_shared::bigint::Zero;
 use fvm_shared::clock::ChainEpoch;
@@ -17,14 +19,14 @@ mod harness;
 #[test]
 fn construct() {
     let mut rt = new_runtime();
-    let h = new_harness();
+    let h = new_harness(ROOTNET_ID.clone());
     h.construct_and_verify(&mut rt);
     h.check_state();
 }
 
 #[test]
 fn register_subnet() {
-    let (h, mut rt) = setup();
+    let (h, mut rt) = setup_root();
 
     // Register a subnet with 1FIL collateral
     let mut value = TokenAmount::from(10_u64.pow(18));
@@ -70,7 +72,7 @@ fn register_subnet() {
 
 #[test]
 fn add_stake() {
-    let (h, mut rt) = setup();
+    let (h, mut rt) = setup_root();
 
     // Register a subnet with 1FIL collateral
     let value = TokenAmount::from(10_u64.pow(18));
@@ -111,7 +113,7 @@ fn add_stake() {
 
 #[test]
 fn release_stake() {
-    let (h, mut rt) = setup();
+    let (h, mut rt) = setup_root();
 
     // Register a subnet with 1FIL collateral
     let value = TokenAmount::from(10_u64.pow(18));
@@ -168,8 +170,8 @@ fn release_stake() {
 }
 
 #[test]
-fn kill() {
-    let (h, mut rt) = setup();
+fn test_kill() {
+    let (h, mut rt) = setup_root();
 
     // Register a subnet with 1FIL collateral
     let value = TokenAmount::from(10_u64.pow(18));
@@ -194,7 +196,7 @@ fn kill() {
 
 #[test]
 fn checkpoint_commit() {
-    let (h, mut rt) = setup();
+    let (h, mut rt) = setup_root();
 
     // Register a subnet with 1FIL collateral
     let value = TokenAmount::from(10_u64.pow(18));
@@ -276,7 +278,7 @@ fn checkpoint_commit() {
 
 #[test]
 fn checkpoint_crossmsgs() {
-    let (h, mut rt) = setup();
+    let (h, mut rt) = setup_root();
 
     // Register a subnet with 1FIL collateral
     let value = TokenAmount::from(10_u64.pow(18));
@@ -347,4 +349,71 @@ fn checkpoint_crossmsgs() {
     // TODO: Add another checkpoint with cross-messages and include some
     // values to test that the circulating supply is updated correctly.
     // (deferring these tests for when cross-message support is fully implemented).
+}
+
+#[test]
+fn test_fund() {
+    let (h, mut rt) = setup_root();
+
+    // Register a subnet with 1FIL collateral
+    let value = TokenAmount::from(10_u64.pow(18));
+    h.register(&mut rt, &SUBNET_ONE, &value, ExitCode::OK).unwrap();
+
+    let st: State = rt.get_state();
+    assert_eq!(st.total_subnets, 1);
+    let shid = SubnetID::new(&h.net_name, *SUBNET_ONE);
+    let subnet = h.get_subnet(&rt, &shid).unwrap();
+    assert_eq!(subnet.id, shid);
+    assert_eq!(subnet.stake, value);
+    assert_eq!(subnet.circ_supply, TokenAmount::zero());
+    assert_eq!(subnet.status, subnet::Status::Active);
+    h.check_state();
+
+    let funder = Address::new_id(1001);
+    let amount = TokenAmount::from(10_u64.pow(18));
+    h.fund(&mut rt, &funder, &shid, ExitCode::OK, amount.clone(), 1, &amount).unwrap();
+    let funder = Address::new_id(1002);
+    let mut exp_cs = amount.clone() * 2;
+    h.fund(&mut rt, &funder, &shid, ExitCode::OK, amount.clone(), 2, &exp_cs).unwrap();
+    exp_cs += amount.clone();
+    h.fund(&mut rt, &funder, &shid, ExitCode::OK, amount.clone(), 3, &exp_cs).unwrap();
+    // No funds sent
+    h.fund(
+        &mut rt,
+        &funder,
+        &shid,
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        TokenAmount::zero(),
+        3,
+        &exp_cs,
+    )
+    .unwrap();
+
+    // Subnet doesn't exist
+    h.fund(
+        &mut rt,
+        &funder,
+        &SubnetID::new(&h.net_name, *SUBNET_TWO),
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        TokenAmount::zero(),
+        3,
+        &exp_cs,
+    )
+    .unwrap();
+}
+
+#[test]
+fn test_release() {
+    let shid = SubnetID::new(&ROOTNET_ID, *SUBNET_ONE);
+    let (h, mut rt) = setup(shid.clone());
+
+    // Include some funds
+    let releaser = Address::new_id(1001);
+
+    // Release funds
+    let r_amount = TokenAmount::from(5_u64.pow(18));
+    rt.set_balance(2 * r_amount.clone());
+    let prev_cid =
+        h.release(&mut rt, &releaser, ExitCode::OK, r_amount.clone(), 0, &Cid::default()).unwrap();
+    h.release(&mut rt, &releaser, ExitCode::OK, r_amount, 1, &prev_cid).unwrap();
 }


### PR DESCRIPTION
- [x] Migration of SubnetID to ref-fvm and `Account` crate.
- [x] `Fund`, `Release`, `SendCross`