### PR TITLE
Strongly typed CID types in Hierarchical Consensus: TCid, THamt and TAmt

### DIFF
--- a/actors/hierarchical_sca/src/atomic.rs
+++ b/actors/hierarchical_sca/src/atomic.rs
@@ -1,0 +1,10 @@
+use fvm_ipld_encoding::{tuple::*, Cbor};
+
+// TODO: Implement atomic swap.
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct AtomicExec {
+    pub dummy: u64,
+}
+
+impl Cbor for AtomicExec {}

--- a/actors/hierarchical_sca/src/cross.rs
+++ b/actors/hierarchical_sca/src/cross.rs
@@ -150,13 +150,13 @@ impl CrossMsgs {
         let store = MemoryBlockstore::new();
         let mut meta = MetaTag::new(&store)?;
 
-        let mut msgs_array = meta.msgs_cid.get_amt(&store)?;
+        let mut msgs_array = meta.msgs_cid.load(&store)?;
         msgs_array.batch_set(self.msgs.clone())?;
-        meta.msgs_cid.flush_amt(&mut msgs_array)?;
+        meta.msgs_cid.flush(&mut msgs_array)?;
 
-        let mut meta_array = meta.meta_cid.get_amt(&store)?;
+        let mut meta_array = meta.meta_cid.load(&store)?;
         meta_array.batch_set(self.metas.clone())?;
-        meta.meta_cid.flush_amt(&mut meta_array)?;
+        meta.meta_cid.flush(&mut meta_array)?;
 
         let meta_cid: TCid<MetaTag> = TCid::new_cbor(&store, &meta)?;
 

--- a/actors/hierarchical_sca/src/cross.rs
+++ b/actors/hierarchical_sca/src/cross.rs
@@ -150,13 +150,13 @@ impl CrossMsgs {
         let store = MemoryBlockstore::new();
         let mut meta = MetaTag::new(&store)?;
 
-        let mut msgs_array = meta.msgs_cid.load(&store)?;
-        msgs_array.batch_set(self.msgs.clone())?;
-        meta.msgs_cid.flush(msgs_array)?;
+        meta.msgs_cid.update(&store, |msgs_array| {
+            msgs_array.batch_set(self.msgs.clone()).map_err(|e| e.into())
+        })?;
 
-        let mut meta_array = meta.meta_cid.load(&store)?;
-        meta_array.batch_set(self.metas.clone())?;
-        meta.meta_cid.flush(meta_array)?;
+        meta.meta_cid.update(&store, |meta_array| {
+            meta_array.batch_set(self.metas.clone()).map_err(|e| e.into())
+        })?;
 
         let meta_cid: TCid<MetaTag> = TCid::new_cbor(&store, &meta)?;
 

--- a/actors/hierarchical_sca/src/cross.rs
+++ b/actors/hierarchical_sca/src/cross.rs
@@ -152,11 +152,11 @@ impl CrossMsgs {
 
         let mut msgs_array = meta.msgs_cid.load(&store)?;
         msgs_array.batch_set(self.msgs.clone())?;
-        meta.msgs_cid.flush(&mut msgs_array)?;
+        meta.msgs_cid.flush(msgs_array)?;
 
         let mut meta_array = meta.meta_cid.load(&store)?;
         meta_array.batch_set(self.metas.clone())?;
-        meta.meta_cid.flush(&mut meta_array)?;
+        meta.meta_cid.flush(meta_array)?;
 
         let meta_cid: TCid<MetaTag> = TCid::new_cbor(&store, &meta)?;
 

--- a/actors/hierarchical_sca/src/cross.rs
+++ b/actors/hierarchical_sca/src/cross.rs
@@ -151,7 +151,7 @@ impl CrossMsgs {
         meta_array.batch_set(self.metas.clone())?;
         meta.meta_cid.flush_amt(&mut meta_array)?;
 
-        let meta_cid: TCid<MetaTag, codes::Blake2b256> = TCid::new_cbor(&store, &meta)?;
+        let meta_cid: TCid<MetaTag> = TCid::new_cbor(&store, &meta)?;
 
         Ok(meta_cid.cid())
     }

--- a/actors/hierarchical_sca/src/cross.rs
+++ b/actors/hierarchical_sca/src/cross.rs
@@ -1,11 +1,10 @@
 use anyhow::anyhow;
-use cid::multihash::Code;
 use cid::Cid;
-use fil_actors_runtime::{Array, BURNT_FUNDS_ACTOR_ADDR};
+use fil_actors_runtime::BURNT_FUNDS_ACTOR_ADDR;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;
-use fvm_ipld_encoding::{CborStore, RawBytes};
+use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::{Address, SubnetID};
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::econ::TokenAmount;

--- a/actors/hierarchical_sca/src/lib.rs
+++ b/actors/hierarchical_sca/src/lib.rs
@@ -27,6 +27,7 @@ pub use self::types::*;
 #[cfg(feature = "fil-actor")]
 fil_actors_runtime::wasm_trampoline!(Actor);
 
+pub mod atomic;
 pub mod checkpoint;
 mod cross;
 #[doc(hidden)]

--- a/actors/hierarchical_sca/src/lib.rs
+++ b/actors/hierarchical_sca/src/lib.rs
@@ -33,6 +33,7 @@ mod cross;
 pub mod ext;
 mod state;
 pub mod subnet;
+pub mod tcid;
 mod types;
 
 /// SCA actor methods available

--- a/actors/hierarchical_sca/src/subnet.rs
+++ b/actors/hierarchical_sca/src/subnet.rs
@@ -64,14 +64,11 @@ impl Subnet {
         store: &BS,
         msg: &StorableMsg,
     ) -> anyhow::Result<()> {
-        let mut crossmsgs = self.top_down_msgs.load(store)?;
-
-        crossmsgs
-            .set(msg.nonce, msg.clone())
-            .map_err(|e| anyhow!("failed to set crossmsg meta array: {}", e))?;
-
-        self.top_down_msgs.flush(crossmsgs)?;
-        Ok(())
+        self.top_down_msgs.update(store, |crossmsgs| {
+            crossmsgs
+                .set(msg.nonce, msg.clone())
+                .map_err(|e| anyhow!("failed to set crossmsg meta array: {}", e))
+        })
     }
 
     pub(crate) fn release_supply(&mut self, value: &TokenAmount) -> anyhow::Result<()> {

--- a/actors/hierarchical_sca/src/subnet.rs
+++ b/actors/hierarchical_sca/src/subnet.rs
@@ -60,13 +60,13 @@ impl Subnet {
         store: &BS,
         msg: &StorableMsg,
     ) -> anyhow::Result<()> {
-        let mut crossmsgs = self.top_down_msgs.get_amt(store)?;
+        let mut crossmsgs = self.top_down_msgs.load(store)?;
 
         crossmsgs
             .set(msg.nonce, msg.clone())
             .map_err(|e| anyhow!("failed to set crossmsg meta array: {}", e))?;
 
-        self.top_down_msgs.flush_amt(&mut crossmsgs)
+        self.top_down_msgs.flush(&mut crossmsgs)
     }
 
     pub(crate) fn release_supply(&mut self, value: &TokenAmount) -> anyhow::Result<()> {

--- a/actors/hierarchical_sca/src/tcid.rs
+++ b/actors/hierarchical_sca/src/tcid.rs
@@ -2,7 +2,9 @@ use std::{any::type_name, marker::PhantomData};
 
 use anyhow::{anyhow, Error, Result};
 use cid::Cid;
-use fil_actors_runtime::{make_empty_map, make_map_with_root_and_bitwidth};
+use fil_actors_runtime::{
+    builtin::HAMT_BIT_WIDTH, make_empty_map, make_map_with_root_and_bitwidth,
+};
 use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::{Cbor, CborStore};
 use fvm_ipld_hamt::Hamt;
@@ -50,7 +52,7 @@ pub struct TCid<T, C = codes::Blake2b256> {
 }
 
 /// Static typing information for HAMT fields.
-pub struct THamt<K, V, const W: u32> {
+pub struct THamt<K, V, const W: u32 = HAMT_BIT_WIDTH> {
     _phantom_k: PhantomData<K>,
     _phantom_v: PhantomData<V>,
 }
@@ -125,12 +127,12 @@ mod test {
     use fvm_ipld_blockstore::Blockstore;
     use fvm_ipld_encoding::{tuple::*, Cbor};
     use fvm_ipld_hamt::BytesKey;
-    use fvm_shared::{clock::ChainEpoch, HAMT_BIT_WIDTH};
+    use fvm_shared::clock::ChainEpoch;
 
     #[derive(Serialize_tuple, Deserialize_tuple)]
     struct State {
         pub child_state: Option<TCid<State>>,
-        pub checkpoints: TCid<THamt<ChainEpoch, Checkpoint, HAMT_BIT_WIDTH>>,
+        pub checkpoints: TCid<THamt<ChainEpoch, Checkpoint>>,
     }
 
     impl Cbor for State {}

--- a/actors/hierarchical_sca/src/tcid.rs
+++ b/actors/hierarchical_sca/src/tcid.rs
@@ -5,7 +5,7 @@ use cid::Cid;
 use fil_actors_runtime::{
     builtin::HAMT_BIT_WIDTH, make_empty_map, make_map_with_root_and_bitwidth,
 };
-use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
+use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{Cbor, CborStore};
 use fvm_ipld_hamt::Hamt;
 
@@ -78,8 +78,7 @@ impl<'d, T, C> serde::Deserialize<'d> for TCid<T, C> {
 
 /// Operations on primitive types that can directly be read/written from/to CBOR.
 impl<T: Cbor, C: CodeType> TCid<T, C> {
-    pub fn new_cbor(value: &T) -> Result<Self> {
-        let store = MemoryBlockstore::new();
+    pub fn new_cbor<S: Blockstore>(store: &S, value: &T) -> Result<Self> {
         let cid = store.put_cbor(value, C::code())?;
         Ok(TCid { cid, _phantom_t: PhantomData, _phantom_c: PhantomData })
     }

--- a/actors/hierarchical_sca/src/tcid.rs
+++ b/actors/hierarchical_sca/src/tcid.rs
@@ -117,16 +117,11 @@ impl<T: Cbor, C: CodeType> TCid<T, C> {
     }
 }
 
-/// The default for `TCid` is the same as it was for `Cid`,
-/// but only for types that have a direct CBOR representation,
-/// meaning that the default `Cid` would not work as a HAMT for example.
-impl<T: Cbor, C> Default for TCid<T, C> {
+// This is different than just `Cid::default()`. It's also
+// different from what the default for HAMT or AMT is.
+impl<T: Cbor + Default, C: CodeType> Default for TCid<T, C> {
     fn default() -> Self {
-        Self {
-            cid: Default::default(),
-            _phantom_t: Default::default(),
-            _phantom_c: Default::default(),
-        }
+        Self::new_cbor(&MemoryBlockstore::new(), &T::default()).unwrap()
     }
 }
 

--- a/actors/hierarchical_sca/src/tcid.rs
+++ b/actors/hierarchical_sca/src/tcid.rs
@@ -1,0 +1,83 @@
+use std::marker::PhantomData;
+
+use anyhow::{anyhow, Error, Result};
+use cid::{multihash, Cid};
+use fil_actors_runtime::make_map_with_root_and_bitwidth;
+use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::{tuple::*, Cbor, CborStore};
+use fvm_ipld_hamt::Hamt;
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct TCid<T> {
+    cid: Cid,
+    name: String,
+    code: multihash::Code,
+    _phantom: PhantomData<T>,
+}
+
+pub struct THamt<K, V, const W: u32> {
+    _phantom_k: PhantomData<K>,
+    _phantom_v: PhantomData<V>,
+}
+
+impl<T: Cbor> TCid<T> {
+    pub fn get_cbor<S: Blockstore>(&self, store: &S) -> Result<Option<T>> {
+        store.get_cbor(&self.cid)
+    }
+
+    pub fn put_cbor<S: Blockstore>(&mut self, store: &S, value: &T) -> Result<()> {
+        let cid = store.put_cbor(value, self.code)?;
+        self.cid = cid;
+        Ok(())
+    }
+}
+
+impl<K, V: Cbor, const W: u32> TCid<THamt<K, V, W>> {
+    pub fn get_cbor<'s, S: Blockstore>(&self, store: &'s S) -> Result<Hamt<&'s S, V>, Error> {
+        make_map_with_root_and_bitwidth::<S, V>(&self.cid, store, W)
+            .map_err(|e| anyhow!("error loading {}: {}", self.name, e))
+    }
+
+    pub fn flush_cbor<'s, S: Blockstore>(&mut self, value: &mut Hamt<&'s S, V>) -> Result<()> {
+        let cid = value.flush()?;
+        self.cid = cid;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{TCid, THamt};
+    use crate::Checkpoint;
+    use fil_actors_runtime::ActorDowncast;
+    use fvm_ipld_blockstore::Blockstore;
+    use fvm_ipld_encoding::{tuple::*, Cbor};
+    use fvm_ipld_hamt::BytesKey;
+    use fvm_shared::{clock::ChainEpoch, HAMT_BIT_WIDTH};
+
+    #[derive(Serialize_tuple, Deserialize_tuple)]
+    struct State {
+        pub child_state: Option<TCid<State>>,
+        pub checkpoints: TCid<THamt<ChainEpoch, Checkpoint, HAMT_BIT_WIDTH>>,
+    }
+
+    impl Cbor for State {}
+
+    impl State {
+        /// flush a checkpoint
+        fn flush_checkpoint<BS: Blockstore>(
+            &mut self,
+            store: &BS,
+            ch: &Checkpoint,
+        ) -> anyhow::Result<()> {
+            let mut checkpoints = self.checkpoints.get_cbor(store)?;
+
+            let epoch = ch.epoch();
+            checkpoints.set(BytesKey::from(epoch.to_ne_bytes().to_vec()), ch.clone()).map_err(
+                |e| e.downcast_wrap(format!("failed to set checkpoint for epoch {}", epoch)),
+            )?;
+
+            self.checkpoints.flush_cbor(&mut checkpoints)
+        }
+    }
+}

--- a/actors/hierarchical_sca/src/tcid.rs
+++ b/actors/hierarchical_sca/src/tcid.rs
@@ -24,6 +24,7 @@ pub mod codes {
     macro_rules! code_types {
     ($($code:ident => $typ:ident),+) => {
         $(
+          #[derive(PartialEq, Eq, Clone, Debug)]
           pub struct $typ;
 
           impl CodeType for $typ {
@@ -47,6 +48,7 @@ pub mod codes {
 
 /// Static typing information for `Cid` fields to help
 /// read and write data safely.
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct TCid<T, C = codes::Blake2b256> {
     cid: Cid,
     _phantom_t: PhantomData<T>,
@@ -54,14 +56,22 @@ pub struct TCid<T, C = codes::Blake2b256> {
 }
 
 /// Static typing information for HAMT fields, a.k.a. `Map`.
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct THamt<K, V, const W: u32 = HAMT_BIT_WIDTH> {
     _phantom_k: PhantomData<K>,
     _phantom_v: PhantomData<V>,
 }
 
 /// Static typing information for AMT fields, a.k.a. `Array`.
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct TAmt<V, const W: u32 = AMT_BIT_WIDTH> {
     _phantom_v: PhantomData<V>,
+}
+
+impl<T, C> TCid<T, C> {
+    pub fn cid(&self) -> Cid {
+        self.cid
+    }
 }
 
 /// `TCid` serializes exactly as its underling `Cid`.
@@ -82,6 +92,18 @@ impl<'d, T, C> serde::Deserialize<'d> for TCid<T, C> {
     {
         let cid = Cid::deserialize(deserializer)?;
         Ok(TCid { cid, _phantom_t: PhantomData, _phantom_c: PhantomData })
+    }
+}
+
+/// The default for `TCid` is the same as it was for `Cid`.
+impl<T, C> Default for TCid<T, C> {
+    fn default() -> Self {
+        Self {
+            /// XXX: Not sure this is correct, can we use this as an AMT for example?
+            cid: Default::default(),
+            _phantom_t: Default::default(),
+            _phantom_c: Default::default(),
+        }
     }
 }
 

--- a/actors/hierarchical_sca/src/tcid.rs
+++ b/actors/hierarchical_sca/src/tcid.rs
@@ -1,6 +1,6 @@
 use std::{any::type_name, marker::PhantomData};
 
-use anyhow::{anyhow, Error, Result};
+use anyhow::{anyhow, Result};
 use cid::Cid;
 use fil_actors_runtime::{
     builtin::HAMT_BIT_WIDTH, fvm_ipld_amt::Amt, make_empty_map, make_map_with_root_and_bitwidth,

--- a/actors/hierarchical_sca/tests/harness/mod.rs
+++ b/actors/hierarchical_sca/tests/harness/mod.rs
@@ -316,7 +316,7 @@ impl Harness {
         rt.verify();
 
         let sub = self.get_subnet(rt, id).unwrap();
-        let crossmsgs = sub.top_down_msgs.get_amt(rt.store()).unwrap();
+        let crossmsgs = sub.top_down_msgs.load(rt.store()).unwrap();
         let msg = get_topdown_msg(&crossmsgs, expected_nonce - 1).unwrap().unwrap();
         assert_eq!(&sub.circ_supply, expected_circ_sup);
         assert_eq!(sub.nonce, expected_nonce);
@@ -494,7 +494,7 @@ impl Harness {
         } else {
             // top-down
             let sub = self.get_subnet(rt, &dest.down(&self.net_name).unwrap()).unwrap();
-            let crossmsgs = sub.top_down_msgs.get_amt(rt.store()).unwrap();
+            let crossmsgs = sub.top_down_msgs.load(rt.store()).unwrap();
             let msg = get_topdown_msg(&crossmsgs, nonce - 1).unwrap().unwrap();
             assert_eq!(&sub.circ_supply, expected_circ_sup);
             assert_eq!(sub.nonce, nonce);
@@ -600,7 +600,7 @@ impl Harness {
 
             if sto != st.network_name {
                 let sub = self.get_subnet(rt, &sto.down(&self.net_name).unwrap()).unwrap();
-                let crossmsgs = sub.top_down_msgs.get_amt(rt.store()).unwrap();
+                let crossmsgs = sub.top_down_msgs.load(rt.store()).unwrap();
                 let msg = get_topdown_msg(&crossmsgs, td_nonce).unwrap().unwrap();
                 assert_eq!(&msg.from, from);
                 assert_eq!(&msg.to, to);

--- a/actors/hierarchical_sca/tests/harness/mod.rs
+++ b/actors/hierarchical_sca/tests/harness/mod.rs
@@ -101,7 +101,7 @@ impl Harness {
         assert_eq!(st.bottomup_msg_meta, empty_bottomup_array);
         verify_empty_map(rt, st.subnets.cid());
         verify_empty_map(rt, st.checkpoints.cid());
-        verify_empty_map(rt, st.check_msg_registry);
+        verify_empty_map(rt, st.check_msg_registry.cid());
         verify_empty_map(rt, st.atomic_exec_registry);
     }
 
@@ -381,12 +381,7 @@ impl Harness {
         let chmeta_ind = ch.crossmsg_meta_index(&self.net_name, &parent).unwrap();
         let chmeta = &ch.data.cross_msgs[chmeta_ind];
 
-        let cross_reg = make_map_with_root_and_bitwidth::<_, CrossMsgs>(
-            &st.check_msg_registry,
-            rt.store(),
-            HAMT_BIT_WIDTH,
-        )
-        .unwrap();
+        let cross_reg = st.check_msg_registry.load(rt.store()).unwrap();
         let meta = get_cross_msgs(&cross_reg, &chmeta.msgs_cid).unwrap().unwrap();
         let msg = meta.msgs[expected_nonce as usize].clone();
 
@@ -477,12 +472,7 @@ impl Harness {
             let chmeta_ind = ch.crossmsg_meta_index(&self.net_name, &dest).unwrap();
             let chmeta = &ch.data.cross_msgs[chmeta_ind];
 
-            let cross_reg = make_map_with_root_and_bitwidth::<_, CrossMsgs>(
-                &st.check_msg_registry,
-                rt.store(),
-                HAMT_BIT_WIDTH,
-            )
-            .unwrap();
+            let cross_reg = st.check_msg_registry.load(rt.store()).unwrap();
             let meta = get_cross_msgs(&cross_reg, &chmeta.msgs_cid).unwrap().unwrap();
             let msg = meta.msgs[nonce as usize].clone();
 

--- a/actors/hierarchical_sca/tests/harness/mod.rs
+++ b/actors/hierarchical_sca/tests/harness/mod.rs
@@ -100,7 +100,7 @@ impl Harness {
         assert_eq!(st.applied_bottomup_nonce, MAX_NONCE);
         assert_eq!(st.bottomup_msg_meta, empty_bottomup_array);
         verify_empty_map(rt, st.subnets.cid());
-        verify_empty_map(rt, st.checkpoints);
+        verify_empty_map(rt, st.checkpoints.cid());
         verify_empty_map(rt, st.check_msg_registry);
         verify_empty_map(rt, st.atomic_exec_registry);
     }

--- a/actors/hierarchical_sca/tests/harness/mod.rs
+++ b/actors/hierarchical_sca/tests/harness/mod.rs
@@ -19,9 +19,9 @@ use lazy_static::lazy_static;
 use fil_actor_hierarchical_sca::checkpoint::ChildCheck;
 use fil_actor_hierarchical_sca::ext;
 use fil_actor_hierarchical_sca::{
-    get_topdown_msg, is_bottomup, Checkpoint, ConstructorParams, CrossMsgArray, CrossMsgMeta,
-    CrossMsgParams, CrossMsgs, FundParams, HCMsgType, Method, State, StorableMsg, Subnet,
-    CROSSMSG_AMT_BITWIDTH, DEFAULT_CHECKPOINT_PERIOD, MAX_NONCE, MIN_COLLATERAL_AMOUNT,
+    get_topdown_msg, is_bottomup, Checkpoint, ConstructorParams, CrossMsgMeta, CrossMsgParams,
+    CrossMsgs, FundParams, HCMsgType, Method, State, StorableMsg, Subnet, CROSSMSG_AMT_BITWIDTH,
+    DEFAULT_CHECKPOINT_PERIOD, MAX_NONCE, MIN_COLLATERAL_AMOUNT,
 };
 use fil_actors_runtime::builtin::HAMT_BIT_WIDTH;
 use fil_actors_runtime::runtime::Runtime;
@@ -316,7 +316,7 @@ impl Harness {
         rt.verify();
 
         let sub = self.get_subnet(rt, id).unwrap();
-        let crossmsgs = CrossMsgArray::load(&sub.top_down_msgs, rt.store()).unwrap();
+        let crossmsgs = sub.top_down_msgs.get_amt(rt.store()).unwrap();
         let msg = get_topdown_msg(&crossmsgs, expected_nonce - 1).unwrap().unwrap();
         assert_eq!(&sub.circ_supply, expected_circ_sup);
         assert_eq!(sub.nonce, expected_nonce);
@@ -494,7 +494,7 @@ impl Harness {
         } else {
             // top-down
             let sub = self.get_subnet(rt, &dest.down(&self.net_name).unwrap()).unwrap();
-            let crossmsgs = CrossMsgArray::load(&sub.top_down_msgs, rt.store()).unwrap();
+            let crossmsgs = sub.top_down_msgs.get_amt(rt.store()).unwrap();
             let msg = get_topdown_msg(&crossmsgs, nonce - 1).unwrap().unwrap();
             assert_eq!(&sub.circ_supply, expected_circ_sup);
             assert_eq!(sub.nonce, nonce);
@@ -600,7 +600,7 @@ impl Harness {
 
             if sto != st.network_name {
                 let sub = self.get_subnet(rt, &sto.down(&self.net_name).unwrap()).unwrap();
-                let crossmsgs = CrossMsgArray::load(&sub.top_down_msgs, rt.store()).unwrap();
+                let crossmsgs = sub.top_down_msgs.get_amt(rt.store()).unwrap();
                 let msg = get_topdown_msg(&crossmsgs, td_nonce).unwrap().unwrap();
                 assert_eq!(&msg.from, from);
                 assert_eq!(&msg.to, to);

--- a/actors/hierarchical_sca/tests/harness/mod.rs
+++ b/actors/hierarchical_sca/tests/harness/mod.rs
@@ -99,7 +99,7 @@ impl Harness {
         assert_eq!(st.check_period, DEFAULT_CHECKPOINT_PERIOD);
         assert_eq!(st.applied_bottomup_nonce, MAX_NONCE);
         assert_eq!(st.bottomup_msg_meta, empty_bottomup_array);
-        verify_empty_map(rt, st.subnets);
+        verify_empty_map(rt, st.subnets.cid());
         verify_empty_map(rt, st.checkpoints);
         verify_empty_map(rt, st.check_msg_registry);
         verify_empty_map(rt, st.atomic_exec_registry);
@@ -621,8 +621,7 @@ impl Harness {
 
     pub fn get_subnet(&self, rt: &MockRuntime, id: &SubnetID) -> Option<Subnet> {
         let st: State = rt.get_state();
-        let subnets =
-            make_map_with_root_and_bitwidth(&st.subnets, rt.store(), HAMT_BIT_WIDTH).unwrap();
+        let subnets = st.subnets.load(rt.store()).unwrap();
         subnets.get(&id.to_bytes()).unwrap().cloned()
     }
 }

--- a/actors/hierarchical_sca/tests/harness/mod.rs
+++ b/actors/hierarchical_sca/tests/harness/mod.rs
@@ -102,7 +102,7 @@ impl Harness {
         verify_empty_map(rt, st.subnets.cid());
         verify_empty_map(rt, st.checkpoints.cid());
         verify_empty_map(rt, st.check_msg_registry.cid());
-        verify_empty_map(rt, st.atomic_exec_registry);
+        verify_empty_map(rt, st.atomic_exec_registry.cid());
     }
 
     pub fn register(

--- a/actors/hierarchical_sca/tests/harness/mod.rs
+++ b/actors/hierarchical_sca/tests/harness/mod.rs
@@ -98,7 +98,7 @@ impl Harness {
         assert_eq!(st.min_stake, TokenAmount::from(MIN_COLLATERAL_AMOUNT));
         assert_eq!(st.check_period, DEFAULT_CHECKPOINT_PERIOD);
         assert_eq!(st.applied_bottomup_nonce, MAX_NONCE);
-        assert_eq!(st.bottomup_msg_meta, empty_bottomup_array);
+        assert_eq!(st.bottomup_msg_meta.cid(), empty_bottomup_array);
         verify_empty_map(rt, st.subnets.cid());
         verify_empty_map(rt, st.checkpoints.cid());
         verify_empty_map(rt, st.check_msg_registry.cid());

--- a/actors/hierarchical_sca/tests/sca_actor_test.rs
+++ b/actors/hierarchical_sca/tests/sca_actor_test.rs
@@ -1,7 +1,6 @@
 use cid::Cid;
 use fil_actor_hierarchical_sca::{
-    get_bottomup_msg, subnet, Actor as SCAActor, Checkpoint, CrossMsgMetaArray, State,
-    DEFAULT_CHECKPOINT_PERIOD,
+    get_bottomup_msg, subnet, Actor as SCAActor, Checkpoint, State, DEFAULT_CHECKPOINT_PERIOD,
 };
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::BURNT_FUNDS_ACTOR_ADDR;
@@ -336,7 +335,7 @@ fn checkpoint_crossmsgs() {
     let prev_cid = ch.cid();
     assert_eq!(has_cid(&child_check.checks, &prev_cid), true);
 
-    let crossmsgs = CrossMsgMetaArray::load(&st.bottomup_msg_meta, rt.store()).unwrap();
+    let crossmsgs = st.bottomup_msg_meta.load(rt.store()).unwrap();
     for item in 0..=2 {
         get_bottomup_msg(&crossmsgs, item).unwrap().unwrap();
     }
@@ -378,7 +377,7 @@ fn checkpoint_crossmsgs() {
     assert_eq!(&child_check.checks.len(), &2);
     assert_eq!(has_cid(&child_check.checks, &ch.cid()), true);
 
-    let crossmsgs = CrossMsgMetaArray::load(&st.bottomup_msg_meta, rt.store()).unwrap();
+    let crossmsgs = &st.bottomup_msg_meta.load(rt.store()).unwrap();
     for item in 0..=2 {
         get_bottomup_msg(&crossmsgs, item).unwrap().unwrap();
     }


### PR DESCRIPTION
This PR adds a `TCid` type as [discussed](https://filecoinproject.slack.com/archives/C02D73MHM63/p1656070176279139?thread_ts=1655890801.501389&cid=C02D73MHM63) on Slack. 

In particular I wanted to see how to get around not having the [generic_associated_types](https://rust-lang.github.io/rfcs/1598-generic_associated_types.html) feature available on the `stable` Rust version we use to compile the project. This would make it possible to have a trait that can return a type that is generic in `Blockstorage`, and thus provide a uniform interface to all storage access. 

Without that, the next best thing I could think of is to have special methods that are only available if the parameter of `TCid` is for example a HAMT. In that context, the method knows that it's return value is going to be a `Hamt`, so there's no problem. We can provide these for the most common complex types, and get type safety, as it would still be impossible to overwrite a `Hamt` with an `Amt` for example. 

UPDATE: I left his PR open for reference, but I think https://github.com/adlrocha/builtin-actors/pull/8 provides an easier API. 