### PR TITLE
Return ActorError::illegal_state in load.

### DIFF
--- a/actors/hierarchical_sca/src/tcid/link.rs
+++ b/actors/hierarchical_sca/src/tcid/link.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 
 use super::{CodeType, TCid, TCidContent};
 use crate::tcid_ops;
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
 use fvm_ipld_encoding::CborStore;
 use serde::de::DeserializeOwned;
@@ -73,16 +73,12 @@ where
         Ok(Self::from(cid))
     }
 
-    /// Read the underlying `Cid` from the store or return an error if not found.
-    pub fn load<'s, S: Blockstore>(&self, store: &'s S) -> Result<StoreContent<'s, S, T>> {
-        match store.get_cbor(&self.cid)? {
-            Some(content) => Ok(StoreContent { store, content }),
-            None => Err(anyhow!(
-                "error loading {}: Cid ({}) did not match any in database",
-                type_name::<Self>(),
-                self.cid.to_string()
-            )),
-        }
+    /// Read the underlying `Cid` from the store, if it exists.
+    pub fn maybe_load<'s, S: Blockstore>(
+        &self,
+        store: &'s S,
+    ) -> Result<Option<StoreContent<'s, S, T>>> {
+        Ok(store.get_cbor(&self.cid)?.map(|content| StoreContent { store, content }))
     }
 
     /// Put the value into the store and overwrite the `Cid`.


### PR DESCRIPTION
The PR changes the `THamt`, `TAmt` and `TLink` types to implement `maybe_load` instead of `load`, and moves `load` into the `tcid_ops` macro, where we can provide uniform treatment of missing data. 

`load` will still return `anyhow::Result` with an `anyhow::Error`, but it will wrap an `ActorError::illegal_state` which can be downcasted by the top level handler to use `USR_ILLEGAL_STATE` as an exit code. We could have picked `USR_NOT_FOUND`, but I wanted to keep using the same code I saw before, and I figured someone using `load` should be pretty confident that the data _should_ be there, otherwise they should use `maybe_load`. (Perhaps we can add a `load_or_err` method that takes an exit code).

I first wanted to actually return `ActorError` instead of `anyhow` but the other errors don't have automatic conversions to `ActorError`, so `?` doesn't work. The wrap-then-downcast method seems to be the way. 