### PR TITLE
Using Option for previous checkpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "1.0.0-rc.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd162cff8cab78c3798762bc6879429ecbd0f5515856bcb3bc31d197208db70"
+checksum = "d013aaca686496e85886d96e5c4c228555141849d59347d1f22d793d5be2572b"
 dependencies = [
  "cid",
  "fvm_ipld_encoding",

--- a/actors/hierarchical_sca/src/checkpoint.rs
+++ b/actors/hierarchical_sca/src/checkpoint.rs
@@ -12,7 +12,7 @@ use fvm_shared::econ::TokenAmount;
 use crate::tcid::TCid;
 use crate::tcid::TLink;
 
-#[derive(Default, PartialEq, Eq, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
+#[derive(PartialEq, Eq, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct Checkpoint {
     pub data: CheckData,
     #[serde(with = "serde_bytes")]
@@ -22,10 +22,7 @@ impl Cbor for Checkpoint {}
 
 impl Checkpoint {
     pub fn new(id: SubnetID, epoch: ChainEpoch) -> Self {
-        Self {
-            data: CheckData { source: id, epoch: epoch, ..Default::default() },
-            ..Default::default()
-        }
+        Self { data: CheckData::new(id, epoch), sig: Vec::new() }
     }
 
     /// return cid for the checkpoint
@@ -57,7 +54,7 @@ impl Checkpoint {
     }
 
     /// return the cid of the previous checkpoint this checkpoint points to.
-    pub fn prev_check(&self) -> &TCid<TLink<Checkpoint>> {
+    pub fn prev_check(&self) -> &Option<TCid<TLink<Checkpoint>>> {
         &self.data.prev_check
     }
 
@@ -118,15 +115,27 @@ impl Checkpoint {
     }
 }
 
-#[derive(Default, PartialEq, Eq, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
+#[derive(PartialEq, Eq, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct CheckData {
     pub source: SubnetID,
     #[serde(with = "serde_bytes")]
     pub tip_set: Vec<u8>,
     pub epoch: ChainEpoch,
-    pub prev_check: TCid<TLink<Checkpoint>>,
+    pub prev_check: Option<TCid<TLink<Checkpoint>>>,
     pub children: Vec<ChildCheck>,
     pub cross_msgs: Vec<CrossMsgMeta>,
+}
+impl CheckData {
+    pub fn new(id: SubnetID, epoch: ChainEpoch) -> Self {
+        Self {
+            source: id,
+            tip_set: Vec::new(),
+            epoch,
+            prev_check: None,
+            children: Vec::new(),
+            cross_msgs: Vec::new(),
+        }
+    }
 }
 impl Cbor for CheckData {}
 

--- a/actors/hierarchical_sca/src/lib.rs
+++ b/actors/hierarchical_sca/src/lib.rs
@@ -318,7 +318,7 @@ impl Actor {
                             ));
                         }
                         // check that the previous cid is consistent with the previous one
-                        if sub.prev_checkpoint.cid() != commit.prev_check() {
+                        if sub.prev_checkpoint.cid() != commit.prev_check().cid() {
                             return Err(actor_error!(
                                 illegal_argument,
                                 "previous checkpoint not consistente with previous one"

--- a/actors/hierarchical_sca/src/lib.rs
+++ b/actors/hierarchical_sca/src/lib.rs
@@ -310,15 +310,17 @@ impl Actor {
 
                     // if this is not the first checkpoint we need to perform some
                     // additional verifications.
-                    if sub.prev_checkpoint != Checkpoint::default() {
-                        if sub.prev_checkpoint.epoch() > commit.epoch() {
+                    if let Some(ref prev_checkpoint) = sub.prev_checkpoint {
+                        if prev_checkpoint.epoch() > commit.epoch() {
                             return Err(actor_error!(
                                 illegal_argument,
                                 "checkpoint being committed belongs to the past"
                             ));
                         }
                         // check that the previous cid is consistent with the previous one
-                        if sub.prev_checkpoint.cid() != commit.prev_check().cid() {
+                        if commit.prev_check().as_ref().map(|c| c.cid())
+                            != Some(prev_checkpoint.cid())
+                        {
                             return Err(actor_error!(
                                 illegal_argument,
                                 "previous checkpoint not consistente with previous one"
@@ -356,7 +358,7 @@ impl Actor {
                     })?;
 
                     // update prev_check for child
-                    sub.prev_checkpoint = commit;
+                    sub.prev_checkpoint = Some(commit);
                     // flush subnet
                     st.flush_subnet(rt.store(), &sub).map_err(|e| {
                         e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "error flushing subnet")

--- a/actors/hierarchical_sca/src/state.rs
+++ b/actors/hierarchical_sca/src/state.rs
@@ -106,7 +106,7 @@ impl State {
                     circ_supply: TokenAmount::zero(),
                     status: Status::Active,
                     nonce: 0,
-                    prev_checkpoint: Checkpoint::default(),
+                    prev_checkpoint: None,
                 };
                 set_subnet(subnets, &id, subnet)?;
                 Ok(true)

--- a/actors/hierarchical_sca/src/subnet.rs
+++ b/actors/hierarchical_sca/src/subnet.rs
@@ -33,7 +33,7 @@ pub struct Subnet {
     #[serde(with = "bigint_ser")]
     pub circ_supply: TokenAmount,
     pub status: Status,
-    pub prev_checkpoint: Checkpoint,
+    pub prev_checkpoint: Option<Checkpoint>,
 }
 
 impl Cbor for Subnet {}

--- a/actors/hierarchical_sca/tests/harness/mod.rs
+++ b/actors/hierarchical_sca/tests/harness/mod.rs
@@ -2,6 +2,8 @@ use anyhow::anyhow;
 use cid::multihash::Code;
 use cid::multihash::MultihashDigest;
 use cid::Cid;
+use fil_actor_hierarchical_sca::tcid::TCid;
+use fil_actor_hierarchical_sca::tcid::TCidContent;
 use fil_actors_runtime::test_utils::expect_abort;
 use fil_actors_runtime::Array;
 use fvm_ipld_blockstore::Blockstore;
@@ -629,8 +631,8 @@ pub fn has_childcheck_source<'a>(
     children.iter().find(|m| source == &m.source)
 }
 
-pub fn has_cid<'a>(children: &'a Vec<Cid>, cid: &Cid) -> bool {
-    children.iter().any(|c| c == cid)
+pub fn has_cid<'a, T: TCidContent>(children: &'a Vec<TCid<T>>, cid: &Cid) -> bool {
+    children.iter().any(|c| c.cid() == *cid)
 }
 
 pub fn add_msg_meta(

--- a/actors/hierarchical_sca/tests/sca_actor_test.rs
+++ b/actors/hierarchical_sca/tests/sca_actor_test.rs
@@ -1,4 +1,5 @@
 use cid::Cid;
+use fil_actor_hierarchical_sca::tcid::TCid;
 use fil_actor_hierarchical_sca::{
     get_bottomup_msg, subnet, Actor as SCAActor, Checkpoint, State, DEFAULT_CHECKPOINT_PERIOD,
 };
@@ -232,7 +233,7 @@ fn checkpoint_commit() {
 
     // Append a new checkpoint for the same subnet
     let mut ch = Checkpoint::new(shid.clone(), epoch + 11);
-    ch.data.prev_check = prev_cid;
+    ch.data.prev_check = TCid::from(prev_cid);
     h.commit_child_check(&mut rt, &shid, &ch, ExitCode::OK, TokenAmount::zero()).unwrap();
     let st: State = rt.get_state();
     let commit = st.get_window_checkpoint(rt.store(), epoch).unwrap();
@@ -353,7 +354,7 @@ fn checkpoint_crossmsgs() {
     h.fund(&mut rt, &funder, &shid, ExitCode::OK, amount.clone(), 1, &amount).unwrap();
 
     let mut ch = Checkpoint::new(shid.clone(), epoch + 9);
-    ch.data.prev_check = prev_cid;
+    ch.data.prev_check = TCid::from(prev_cid);
     add_msg_meta(
         &mut ch,
         &shid,

--- a/actors/hierarchical_sca/tests/sca_actor_test.rs
+++ b/actors/hierarchical_sca/tests/sca_actor_test.rs
@@ -233,7 +233,7 @@ fn checkpoint_commit() {
 
     // Append a new checkpoint for the same subnet
     let mut ch = Checkpoint::new(shid.clone(), epoch + 11);
-    ch.data.prev_check = TCid::from(prev_cid);
+    ch.data.prev_check = Some(TCid::from(prev_cid));
     h.commit_child_check(&mut rt, &shid, &ch, ExitCode::OK, TokenAmount::zero()).unwrap();
     let st: State = rt.get_state();
     let commit = st.get_window_checkpoint(rt.store(), epoch).unwrap();
@@ -354,7 +354,7 @@ fn checkpoint_crossmsgs() {
     h.fund(&mut rt, &funder, &shid, ExitCode::OK, amount.clone(), 1, &amount).unwrap();
 
     let mut ch = Checkpoint::new(shid.clone(), epoch + 9);
-    ch.data.prev_check = TCid::from(prev_cid);
+    ch.data.prev_check = Some(TCid::from(prev_cid));
     add_msg_meta(
         &mut ch,
         &shid,


### PR DESCRIPTION
Ran into a problem when added `TCid<TLink<Checkpoint>>`, the code used `default()` but its implementation became recursive. Can't lie to the type system about there always being a previous checkpoint. 

I understand if you'd rather use the "empty Cid", so this is up for your discretion.